### PR TITLE
docs(data-docs): add links in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Primary website for the dsmJS user-group, built with [Gatsby](https://www.gatsby
 
 Find common contributing details in our [organization-level contribution guide](https://github.com/dsmjs/.github/CONTRIBUTING.md)
 
+### Data Structure
+
+The data for this site is comprised of data from markdown files.
+See the [content readme](https://github.com/dsmjs/site/tree/master/content)
+for more information on the data structures.
+
 ### Dependencies
 
 ```sh

--- a/content/README.md
+++ b/content/README.md
@@ -1,11 +1,11 @@
 # Content Structure
 
 In this folder you will find content for the following:
-* meetings
-* talks
-* speakers
-* hosts
-* sponsors
+* [meetings](https://github.com/dsmjs/site/tree/master/content/meetings)
+* [talks](https://github.com/dsmjs/site/tree/master/content/talks)
+* [speakers](https://github.com/dsmjs/site/tree/master/content/speakers)
+* [hosts](https://github.com/dsmjs/site/tree/master/content/hosts)
+* [sponsors](https://github.com/dsmjs/site/tree/master/content/sponsors)
 
 They are organized by the following structure:
 ![Data structure for the dsmJS Gatsby Site](./dsmjs-data-structure.png)


### PR DESCRIPTION
Add top level README link to content README. Add links in content README to each data structure
folder.

re #462